### PR TITLE
chore: Update `css-inline` to `0.10`

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,7 +27,7 @@ colorama==0.4.4
 configparser==5.2.0
 crayons==0.4.0
 cryptography==36.0.1
-css-inline==0.8.1
+css-inline==0.10.1
 cssselect==1.1.0
 cssutils==2.3.0
 debugpy==1.5.1


### PR DESCRIPTION
Hi! This PR updates `css-inline` to its latest version